### PR TITLE
Add EndeavourOS support to package manager detection

### DIFF
--- a/nerdfonts_installer.sh
+++ b/nerdfonts_installer.sh
@@ -14,7 +14,7 @@ detect_os_and_set_package_manager() {
             centos|rhel)
                 PKG_MANAGER="sudo yum install -y"
                 ;;
-            arch|manjaro)
+            arch|manjaro|endeavouros)
                 PKG_MANAGER="sudo pacman -Syu --noconfirm"
                 ;;
             *)


### PR DESCRIPTION
## Description

I was having trouble running the script on [EndeavorOS](https://endeavouros.com/) after having success with Arch Linux earlier. As EOS is the same as arch, it will work just the same. Tested the modification locally and it worked perfectly.



## Type of change
Added os string `endeavouros` to `detect_os_and_set_package_manager()` function.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings