### PR TITLE
fix: recognize rocky and almalinux as RHEL-family distros

### DIFF
--- a/nerdfonts_installer.c
+++ b/nerdfonts_installer.c
@@ -283,7 +283,8 @@ static const char *detect_os_and_get_package_manager(void) {
     if (strcmp(os_id, "fedora") == 0)
         return "sudo dnf install -y";
 
-    if (strcmp(os_id, "centos") == 0 || strcmp(os_id, "rhel") == 0)
+    if (strcmp(os_id, "centos") == 0 || strcmp(os_id, "rhel")   == 0 ||
+        strcmp(os_id, "rocky")  == 0 || strcmp(os_id, "almalinux") == 0)
         return "sudo yum install -y";
 
     if (strcmp(os_id, "arch")        == 0 || strcmp(os_id, "manjaro")     == 0 ||

--- a/nerdfonts_installer.sh
+++ b/nerdfonts_installer.sh
@@ -13,7 +13,7 @@ detect_os_and_set_package_manager() {
             fedora)
                 PKG_MANAGER="sudo dnf install -y"
                 ;;
-            centos|rhel)
+            centos|rhel|rocky|almalinux)
                 PKG_MANAGER="sudo yum install -y"
                 ;;
             arch|manjaro|endeavouros|cachyos|garuda|artix|arco|steamos|blackarch)


### PR DESCRIPTION
## Description

`/etc/os-release` reports `ID=rocky` and `ID=almalinux`, neither of which matched the `centos|rhel` case in the OS-detection logic (sh) or the `strcmp` chain (C). Both distros fell through to "Unsupported OS" and aborted before installing dependencies.

Added `rocky` and `almalinux` alongside `centos`/`rhel`, mapped to `yum`, in both `nerdfonts_installer.sh` and `nerdfonts_installer.c`.

Fixes #12

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules