### PR TITLE
fix: remove futile conditional in create_directories

### DIFF
--- a/nerdfonts_installer.c
+++ b/nerdfonts_installer.c
@@ -393,11 +393,11 @@ static void create_directories(void) {
         exit(1);
     }
 
-    if (create_directory_secure(fonts_path) != 0) {
-        // EEXIST is normal for returning users; create_directory_secure already
-        // handles it silently. Any other failure is non-fatal: fonts may still
-        // install if the directory was created by another means.
-    }
+    // EEXIST is normal for returning users; create_directory_secure already
+    // handles it silently. Any other failure is non-fatal: fonts may still
+    // install if the directory was created by another means, so the return
+    // value is intentionally discarded here.
+    (void)create_directory_secure(fonts_path);
 }
 
 // Fetch available fonts from the GitHub Releases API and populate fonts[].


### PR DESCRIPTION
## Description

`create_directory_secure(fonts_path)` was called inside an `if` whose body was empty in every branch — a no-op flagged by CodeQL (#321). Call it directly and discard the return value with `(void)` to make the intentional non-handling explicit.

Fixes #321

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules