### PR TITLE
fix: recognize Omarchy as an Arch-family distro

### DIFF
--- a/nerdfonts_installer.c
+++ b/nerdfonts_installer.c
@@ -287,11 +287,11 @@ static const char *detect_os_and_get_package_manager(void) {
         strcmp(os_id, "rocky")  == 0 || strcmp(os_id, "almalinux") == 0)
         return "sudo yum install -y";
 
-    if (strcmp(os_id, "arch")        == 0 || strcmp(os_id, "manjaro")     == 0 ||
-        strcmp(os_id, "endeavouros") == 0 || strcmp(os_id, "cachyos")     == 0 ||
-        strcmp(os_id, "garuda")      == 0 || strcmp(os_id, "artix")       == 0 ||
-        strcmp(os_id, "arco")        == 0 || strcmp(os_id, "steamos")     == 0 ||
-        strcmp(os_id, "blackarch")   == 0)
+    if (strcmp(os_id, "arch")        == 0 || strcmp(os_id, "manjaro") == 0 ||
+        strcmp(os_id, "endeavouros") == 0 || strcmp(os_id, "cachyos") == 0 ||
+        strcmp(os_id, "garuda")      == 0 || strcmp(os_id, "artix")   == 0 ||
+        strcmp(os_id, "arco")        == 0 || strcmp(os_id, "steamos") == 0 ||
+        strcmp(os_id, "blackarch")   == 0 || strcmp(os_id, "omarchy") == 0)
         return "sudo pacman -Syu --noconfirm";
 
     printf("%sUnsupported OS: %s\n%s", COLOR_RED, os_id, COLOR_RESET);

--- a/nerdfonts_installer.sh
+++ b/nerdfonts_installer.sh
@@ -16,7 +16,7 @@ detect_os_and_set_package_manager() {
             centos|rhel|rocky|almalinux)
                 PKG_MANAGER="sudo yum install -y"
                 ;;
-            arch|manjaro|endeavouros|cachyos|garuda|artix|arco|steamos|blackarch)
+            arch|manjaro|endeavouros|cachyos|omarchy|garuda|artix|arco|steamos|blackarch)
                 PKG_MANAGER="sudo pacman -Syu --noconfirm"
                 ;;
             *)


### PR DESCRIPTION
## Description

`/etc/os-release` reports `ID=omarchy` on Omarchy Linux, an Arch-based distribution. It wasn't included in the Arch-family case in the OS-detection logic (sh) or the `strcmp` chain (C), so it fell through to "Unsupported OS" and aborted before installing dependencies.

Added `omarchy` alongside the other Arch derivatives, mapped to `pacman`, in both `nerdfonts_installer.sh` and `nerdfonts_installer.c`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules