### PR TITLE
docs: general audit and bump minimum supported version to v2026.07.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## ✨ Features
 
-- **🐧 Cross-platform Support** - Works on Arch, Debian, Ubuntu, Fedora, CentOS, RHEL, and Linux Mint
+- **🐧 Cross-platform Support** - Works on Arch, Omarchy, Manjaro, EndeavourOS, Debian, Ubuntu, Linux Mint, Fedora, CentOS, RHEL, Rocky Linux, and AlmaLinux
 - **📦 Automatic Dependencies** - Installs `curl`, `unzip`, and `fontconfig` automatically
 - **🔍 Live Font Discovery** - Fetches current font list from Nerd Fonts **Releases API** (more reliable, no more 404 mismatches)
 - **🎯 Interactive Selection** - Choose specific fonts or install all with one command
@@ -25,7 +25,7 @@
 
 ## 🚀 Quick Start
 > [!IMPORTANT]
-> **Security Notice**: Please ensure you are using version `v2026.06` (or newer). Older versions using the old Contents API are deprecated.
+> **Security Notice**: Please ensure you are using version `v2026.07` (or newer). Older versions using the old Contents API are deprecated and do not have the new OS/distro support.
 
 ### One-Line Installation (Recommended)
 
@@ -87,7 +87,7 @@ sudo apt-get install build-essential libcurl4-openssl-dev libjansson-dev
 # Fedora
 sudo dnf install gcc make libcurl-devel jansson-devel
 
-# CentOS / RHEL
+# CentOS / RHEL / Rocky Linux / AlmaLinux
 sudo yum install gcc make libcurl-devel jansson-devel
 ```
 
@@ -176,6 +176,9 @@ chmod +x nerdfonts_installer.sh
 | **Fedora 34+** | `dnf` | ✅ | ✅ | Recent versions |
 | **CentOS 7/8** | `yum` | ✅ | ❌ | **Use Shell Script** (Binary requires new GLIBC) |
 | **RHEL 7/8/9** | `yum` | ✅ | ⚠️ | RHEL 9 OK, older usage Shell Script |
+| **Rocky Linux** | `yum` | ✅ | ⚠️ | Detected as of latest release; binary compatibility untested |
+| **AlmaLinux** | `yum` | ✅ | ⚠️ | Detected as of latest release; binary compatibility untested |
+| **Omarchy** | `pacman` | ✅ | ⚠️ | Detected as of latest release; binary compatibility untested |
 
 > **Note**: The C Binary is built on Ubuntu Latest and requires a recent GLIBC. For older distributions (CentOS 7, Ubuntu 18.04, etc.), please use the **Shell Script** version.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| >= v2026.01.09 | :white_check_mark: |
-| < v2026.01.09 | :x:                |
+| >= v2026.07.17 | :white_check_mark: |
+| < v2026.07.17 | :x:                |
 
 ## Security Measures
 


### PR DESCRIPTION
## Description

Update the security notice in README.md to point at `v2026.07` and note that older versions lack the new OS/distro detection (Rocky, AlmaLinux, Omarchy).

Update SECURITY.md's supported-versions table to match: `v2026.07.17` is now the security-patch floor, replacing `v2026.01.09`. Versions prior to this tag will no longer receive security fixes.

**Note**: this is a support-policy change, not just a doc sync — it drops security-patch coverage for every release between `v2026.01.09` and `v2026.07.16`. Confirm that's the intended scope before merging.

## Type of change

- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules